### PR TITLE
Correct path on __init__ | README addition for in-code usage

### DIFF
--- a/DLMUSE/__init__.py
+++ b/DLMUSE/__init__.py
@@ -1,1 +1,1 @@
-from .dlmuse_pipeline import run_dlmuse_pipeline
+from DLMUSE.dlmuse_pipeline import run_dlmuse_pipeline

--- a/DLMUSE/__init__.py
+++ b/DLMUSE/__init__.py
@@ -1,1 +1,1 @@
-from dlmuse_pipeline import run_dlmuse_pipeline
+from .dlmuse_pipeline import run_dlmuse_pipeline

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ A pre-trained nnUNet model can be found at our [hugging face account](https://hu
 ```bash
 DLMUSE -i "input_folder" -o "output_folder" -device cpu
 ```
+### In-code usage
+```python
+from DLMUSE import run_dlmuse_pipeline
+...
+run_dlmuse_pipeline(in_dir, out_dir, device)
+```
+
 For more details, please refer to
 
 ```bash


### PR DESCRIPTION
Just a little bug fix, because some python env's can't find the local path(it needs a "."). 
Also added info about how the user can run DLMUSE directly in code.